### PR TITLE
QA Operator Rebrand

### DIFF
--- a/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
+++ b/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
@@ -337,7 +337,7 @@ export function SentryWallet() {
 							) : (
 								<button
 									onClick={startRuntime}
-									className="ml-4 flex flex-row justify-center items-center gap-2 text-lg font-bold text-tertiaryText"
+									className="ml-4 flex flex-row justify-center items-center gap-2 text-lg font-bold text-tertiaryText hover:text-white duration-300 ease-in-out"
 								>
 									<FaPlay className="h-[15px]"/>
 									Start Sentry

--- a/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
+++ b/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
@@ -220,7 +220,7 @@ export function SentryWallet() {
 				<div
 					className="sticky top-0 flex flex-col items-center w-full h-auto z-10">
 					<div
-						className="flex flex-row justify-between items-center w-full py-[15px] bg-primaryBgColor gap-2 border-b border-primaryBorderColor pl-[24px] pr-2">
+						className={`flex flex-row justify-between items-center w-full ${drawerState === null ? "py-[11px]" : "py-[15px]"} bg-primaryBgColor gap-2 border-b border-primaryBorderColor pl-[24px] pr-2`}>
 						<div className="flex flex-row items-center gap-2 w-full max-w-[50%] z-[15]">
 							<span>
 								{sentryRunning && hasAssignedKeys && funded && <GreenPulse size='md'/>}

--- a/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
+++ b/apps/sentry-client-desktop/src/features/home/SentryWallet.tsx
@@ -220,8 +220,8 @@ export function SentryWallet() {
 				<div
 					className="sticky top-0 flex flex-col items-center w-full h-auto z-10">
 					<div
-						className="flex flex-row justify-between items-center w-full py-[22px] bg-primaryBgColor gap-2 border-b border-primaryBorderColor pl-[24px] pr-2">
-						<div className="flex flex-row items-center gap-2 w-full max-w-[50%]">
+						className="flex flex-row justify-between items-center w-full py-[15px] bg-primaryBgColor gap-2 border-b border-primaryBorderColor pl-[24px] pr-2">
+						<div className="flex flex-row items-center gap-2 w-full max-w-[50%] z-[15]">
 							<span>
 								{sentryRunning && hasAssignedKeys && funded && <GreenPulse size='md'/>}
 								{sentryRunning && !hasAssignedKeys && !funded && <YellowPulse size='md'/>}
@@ -318,7 +318,7 @@ export function SentryWallet() {
 									onClick={() => {
 										setDrawerState(DrawerView.Whitelist)
 									}}
-									className={`ml-[10px] flex flex-row justify-center items-center gap-2 text-tertiaryText text-lg font-bold ${!stopRuntime && 'cursor-not-allowed'}`}
+									className={`ml-[10px] flex flex-row justify-center items-center gap-2 text-tertiaryText text-lg font-bold ${!stopRuntime ? 'cursor-not-allowed' : "hover:text-white duration-300"}`}
 									disabled={!stopRuntime}
 								>
 									{stopRuntime ?
@@ -387,7 +387,7 @@ export function SentryWallet() {
 							) : (
 								<a
 									onClick={onRefreshTable}
-									className="flex items-center text-lg text-tertiaryText gap-1 cursor-pointer select-none"
+									className="flex items-center text-lg text-tertiaryText gap-1 cursor-pointer select-none hover:text-white duration-300 ease-in-out"
 								>
 									<MdRefresh/> Refresh
 								</a>

--- a/apps/sentry-client-desktop/src/features/home/SentryWalletHeader.tsx
+++ b/apps/sentry-client-desktop/src/features/home/SentryWalletHeader.tsx
@@ -52,7 +52,7 @@ export function SentryWalletHeader() {
 				) : (
 					<a
 						onClick={onRefreshEthBalance}
-						className="flex items-center text-lg font-bold text-tertiaryText gap-1 cursor-pointer select-none ml-[14px]"
+						className="flex items-center text-lg font-bold text-tertiaryText gap-1 cursor-pointer select-none ml-[14px] hover:text-white duration-300 ease-in-out"
 					>
 						<MdRefresh/> Refresh
 					</a>

--- a/apps/sentry-client-desktop/src/features/home/modals/view-keys/ViewKeysFlow.tsx
+++ b/apps/sentry-client-desktop/src/features/home/modals/view-keys/ViewKeysFlow.tsx
@@ -101,7 +101,7 @@ export function ViewKeysFlow() {
 			<div
 				className="absolute top-0 bottom-0 left-0 right-0 m-auto flex flex-col justify-center items-center gap-4">
 				<FaCircleCheck color={"#16A34A"} size={32}/>
-				<span className="text-lg">Wallet added successfully</span>
+				<span className="text-lg text-bold text-white">Wallet added successfully</span>
 			</div>
 		)
 	}

--- a/apps/sentry-client-desktop/src/features/keys/HasKeys.tsx
+++ b/apps/sentry-client-desktop/src/features/keys/HasKeys.tsx
@@ -176,7 +176,7 @@ export function HasKeys({combinedOwners, combinedLicensesMap, statusMap, isWalle
 					</td>
 					<td className="min-w-[12%] px-4 py-2 text-btnPrimaryBgColor font-bold text-right">
 						<span
-							className="cursor-pointer pr-[3px]"
+							className="cursor-pointer pr-[3px] uppercase hover:text-white duration-300 ease-in-out"
 							onClick={() => window.electron.openExternal(`https://opensea.io/assets/arbitrum/${config.nodeLicenseAddress}/${keyString}`)}
 						>
 							View
@@ -357,16 +357,16 @@ export function HasKeys({combinedOwners, combinedLicensesMap, statusMap, isWalle
 					<div className="w-full overflow-y-auto">
 						<table className="w-full bg-primaryBgColor">
 							<thead className="text-secondaryText text-base sticky top-0 bg-primaryBgColor z-10">
-							<tr className="flex items-center text-left text-base px-6 border-b border-t border-primaryBorderColor">
-								<th className="min-w-[7%] px-2 py-2">KEY ID</th>
-								<th className="min-w-[37%] px-2 py-2">OWNER ADDRESS</th>
-								<th className="min-w-[27%] px-4 py-2">STATUS</th>
-								<th className="min-w-[17%] px-4 py-2 flex items-center justify-end gap-1">
+							<tr className="flex items-center text-left text-base border-b border-t border-primaryBorderColor px-[25px] py-[15px] bg-secondaryBgColor">
+								<th className="min-w-[7%] px-2 py-0">KEY ID</th>
+								<th className="min-w-[37%] px-2 py-0">OWNER ADDRESS</th>
+								<th className="min-w-[27%] px-4 py-0">STATUS</th>
+								<th className="min-w-[17%] px-4 py-0 flex items-center justify-end gap-1">
 									{isBalancesLoading &&
                                         <BiLoaderAlt className="animate-spin w-[18px]" color={"#FF0030"}/>}
 									ACCRUED esXAI
 								</th>
-								<th className="min-w-[12%] px-4 py-2 text-right">OPENSEA URL</th>
+								<th className="min-w-[12%] px-4 py-0 text-right">OPENSEA URL</th>
 							</tr>
 							</thead>
 							<tbody className="relative">{renderKeys()}</tbody>


### PR DESCRIPTION
- fixed sentry wallet page "Restart Sentry" has no onHover
- fixed sentry wallet page - top bar - when i click on the 3 points the dropdown is behind the component under it
- fixed keys page incorrect table head bg on keys page
- fixed keys page table head paddings 8px instead of 15px
- fixed keys page "View" text should be uppercase 
- fixed reduce height of top bar of sentry wallet page (make it equal with keys page)
- fixed text color after wallet was successfully added
- make margin equal for "Actions Required" on sentry wallet page top bar
- added hover effect to "start sentry" button
[Ticket](https://www.pivotaltracker.com/n/projects/2671427/stories/187779137)