### PR TITLE
Fb disabled full screen button

### DIFF
--- a/apps/sentry-client-desktop/electron/main.ts
+++ b/apps/sentry-client-desktop/electron/main.ts
@@ -102,6 +102,7 @@ function createWindow() {
 		minWidth: 1650,
 		minHeight: 900,
 		autoHideMenuBar: true,
+		resizable: false,
 		icon: path.join(process.env.VITE_PUBLIC, 'xai-logo.svg'),
 		webPreferences: {
 			preload: path.join(__dirname, 'preload.js'),


### PR DESCRIPTION
- cancelled resize window for Operator Desktop
task: https://www.pivotaltracker.com/story/show/187822837