### PR TITLE
Operator Rebrand - Nav Bar "Staking" Option

### DIFF
--- a/apps/sentry-client-desktop/src/features/sidebar/SidebarRoot.tsx
+++ b/apps/sentry-client-desktop/src/features/sidebar/SidebarRoot.tsx
@@ -11,6 +11,7 @@ import { TelegramIcon, XaiHeaderIcon } from "@sentry/ui/src/rebrand/icons/IconsC
 import DashboardIconWhite from "@/assets/images/dashboard-icon-white.png";
 import DashboardIconGrey from "@/assets/images/dashboard-icon-grey.png";
 import { useStorage } from "@/features/storage";
+import ExternalLinkIcon from "@sentry/ui/dist/src/rebrand/icons/ExternalLinkIcon";
 
 /**
  * Sidebar component
@@ -38,7 +39,7 @@ export function Sidebar() {
 					className="flex group items-centertext-base w-[5rem] h-[5rem] mb-[37px] font-semibold cursor-pointer bg-hornetSting hover:bg-white duration-200 ease-in px-[20px] py-[23px]"
 					onClick={() => navigate("/")}
 				>
-					<XaiHeaderIcon width={39} height={34} />
+					<XaiHeaderIcon width={39} height={34} fill="fill-white" />
 				</div>
 
 				<div className="w-[237px] mb-[145px]">
@@ -71,7 +72,12 @@ export function Sidebar() {
 						onClick={() => data?.addedWallets?.length && data.addedWallets.length > 0 && window.electron.openExternal('https://app.xai.games')}
 						className={`flex items-center w-[237px] text-xl font-bold ${data?.addedWallets?.length && data.addedWallets.length > 0 ? `text-white cursor-pointer hover:global-clip-path hover:bg-darkRoom` : "text-foggyLondon cursor-auto"} gap-2 py-[11px] pl-[17px]`}
 					>
-						<XaiHeaderIcon width={20} height={20} fill={`${data?.addedWallets?.length && data.addedWallets.length === 0 && "fill-foggyLondon"}`} /> STAKING
+						<XaiHeaderIcon extraClasses="mt-[-4px]" width={20} height={20} fill={`${!data?.addedWallets?.length ? "fill-foggyLondon" : "fill-white"}`} />
+						STAKING
+						<ExternalLinkIcon
+						fill={!data?.addedWallets?.length ? "#5B5757" : "#fff"}
+						extraClasses="mt-[-4px]"
+					/>
 					</a>
 				</div>
 

--- a/apps/sentry-client-desktop/src/features/sidebar/SidebarRoot.tsx
+++ b/apps/sentry-client-desktop/src/features/sidebar/SidebarRoot.tsx
@@ -75,8 +75,7 @@ export function Sidebar() {
 						<XaiHeaderIcon extraClasses="mt-[-4px]" width={20} height={20} fill={`${!data?.addedWallets?.length ? "fill-foggyLondon" : "fill-white"}`} />
 						STAKING
 						<ExternalLinkIcon
-						fill={!data?.addedWallets?.length ? "#5B5757" : "#fff"}
-						extraClasses="mt-[-4px]"
+						extraClasses={{svgClasses: "mt-[-4px]", pathClasses: `${!data?.addedWallets?.length ? "fill-foggyLondon" : "fill-white"}`}}
 					/>
 					</a>
 				</div>

--- a/packages/ui/src/rebrand/icons/ExternalLinkIcon.tsx
+++ b/packages/ui/src/rebrand/icons/ExternalLinkIcon.tsx
@@ -1,6 +1,5 @@
 
 interface ExternalLinkIconProps {
-    fill?: string
     extraClasses?: {
         svgClasses?: string;
         pathClasses?: string;

--- a/packages/ui/src/rebrand/icons/ExternalLinkIcon.tsx
+++ b/packages/ui/src/rebrand/icons/ExternalLinkIcon.tsx
@@ -1,12 +1,15 @@
 
 interface ExternalLinkIconProps {
     fill?: string
-    extraClasses?: string;
+    extraClasses?: {
+        svgClasses?: string;
+        pathClasses?: string;
+    };
 }
-export default function ExternalLinkIcon ({fill = "#fff", extraClasses = ""}: ExternalLinkIconProps) {
-    return <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" className={extraClasses}>
+export default function ExternalLinkIcon ({extraClasses}: ExternalLinkIconProps) {
+    return <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" className={extraClasses?.svgClasses}>
         <path id="Path_4170" data-name="Path 4170"
               d="M9.222,5.667V7.444H4.778v9.778h9.778V12.778h1.778v5.333a.889.889,0,0,1-.889.889H3.889A.889.889,0,0,1,3,18.111V6.556a.889.889,0,0,1,.889-.889ZM19,3v7.111H17.222V6.034L10.3,12.962,9.038,11.7l6.926-6.927H11.889V3Z"
-              transform="translate(-3 -3)" fill={fill}/>
+              transform="translate(-3 -3)" className={extraClasses?.pathClasses}/>
     </svg>
 }

--- a/packages/ui/src/rebrand/icons/ExternalLinkIcon.tsx
+++ b/packages/ui/src/rebrand/icons/ExternalLinkIcon.tsx
@@ -1,0 +1,12 @@
+
+interface ExternalLinkIconProps {
+    fill?: string
+    extraClasses?: string;
+}
+export default function ExternalLinkIcon ({fill = "#fff", extraClasses = ""}: ExternalLinkIconProps) {
+    return <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" className={extraClasses}>
+        <path id="Path_4170" data-name="Path 4170"
+              d="M9.222,5.667V7.444H4.778v9.778h9.778V12.778h1.778v5.333a.889.889,0,0,1-.889.889H3.889A.889.889,0,0,1,3,18.111V6.556a.889.889,0,0,1,.889-.889ZM19,3v7.111H17.222V6.034L10.3,12.962,9.038,11.7l6.926-6.927H11.889V3Z"
+              transform="translate(-3 -3)" fill={fill}/>
+    </svg>
+}

--- a/packages/ui/src/rebrand/icons/IconsComponents.tsx
+++ b/packages/ui/src/rebrand/icons/IconsComponents.tsx
@@ -188,9 +188,9 @@ export const Lock = ({width = 22, height = 23, className = ""}) => {
 }
 
 
-export const XaiHeaderIcon = ({width = 16, height = 16, fill = ""}) => {
+export const XaiHeaderIcon = ({width = 16, height = 16, fill = "", extraClasses = ""}) => {
   return (
-  <svg className={`fill-white ${fill} group-hover:fill-hornetSting duration-200 ease-in"  version="1.0" xmlns="http://www.w3.org/2000/svg`}
+  <svg className={`${fill} group-hover:fill-hornetSting duration-200 ease-in ${extraClasses}`}
  width={width} height={height} viewBox="0 0 600.000000 600.000000"
  preserveAspectRatio="xMidYMid meet">
 <g transform="translate(0.000000,600.000000) scale(0.100000,-0.100000)"


### PR DESCRIPTION
Added Icon to sidebar staking option that prompts user that he will open window in a new browser tab. Improved condition that recolors icons. Updated props for XaiHeaderIcon.
[Ticket](https://www.pivotaltracker.com/n/projects/2671427/stories/187822885)