### PR TITLE
Operator Rebrand - Actions Required Broken View

### DIFF
--- a/apps/sentry-client-desktop/src/features/drawer/ActionsRequiredPromptHandler.tsx
+++ b/apps/sentry-client-desktop/src/features/drawer/ActionsRequiredPromptHandler.tsx
@@ -21,7 +21,7 @@ export function ActionsRequiredPromptHandler() {
 			<BaseCallout extraClasses={{calloutWrapper: "h-[60px] w-[308px]"}} isWarning>
 				<div className="flex flex-row gap-2 items-center mr-3">
 					<WarningIcon width={23} height={20}/>
-					<span className="text-bananaBoat text-lg font-bold">Actions required</span>
+					<span className="text-bananaBoat text-lg font-bold !whitespace-nowrap">Actions required</span>
 				</div>
 				<div>
 				<PrimaryButton


### PR DESCRIPTION
Fixed `Actions required` message was in two lines, when should be as one line
[Ticket](https://www.pivotaltracker.com/story/show/187860139)