### PR TITLE
Operator Rebrand - Fix Checkbox Checked State

### DIFF
--- a/apps/sentry-client-desktop/src/index.css
+++ b/apps/sentry-client-desktop/src/index.css
@@ -105,6 +105,7 @@ body {
 
     .checkboxLabel input:before {
         opacity: 0;
+        transition: opacity .25s ease-in-out;
     }
 
     .checkboxLabel input:checked:before {

--- a/apps/sentry-client-desktop/src/index.css
+++ b/apps/sentry-client-desktop/src/index.css
@@ -102,6 +102,14 @@ body {
         border-bottom: 2px black solid;
         background-clip: padding-box;
     }
+
+    .checkboxLabel input:before {
+        opacity: 0;
+    }
+
+    .checkboxLabel input:checked:before {
+        opacity: 100;
+    }
 }
 
 @layer utilities {


### PR DESCRIPTION
For some reason our checkbox component doesn't work properly on desktop-operator (tailwind opacity classes don't apply at all). I tested it on web-connect and staking - it works. So to avoid any changes for global UI components - i did changes only for dekstop-operator `index.css`
[Ticket](https://www.pivotaltracker.com/n/projects/2671427/stories/187891849)